### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/server.dart
+++ b/lib/src/server.dart
@@ -32,7 +32,7 @@ class Server {
       return _send(http, ErrorResponse.methodNotAllowed([]));
     }
 
-    final body = await http.transform(utf8.decoder).join();
+    final body = await http.cast<List<int>>().transform(utf8.decoder).join();
 
     await request.call(controller, http.requestedUri.queryParametersAll,
         body.isNotEmpty ? json.decode(body) : null);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ author: "Alexey Karapetov <karapetov@gmail.com>"
 description: "JSON:API Server. Supports JSON:API v1.0 (http://jsonapi.org)"
 homepage: "https://github.com/f3ath/json-api-server-dart"
 name: "json_api_server"
-version: "0.0.7"
+version: "0.0.7+1"
 dependencies:
   json_api_document: "^1.0.2"
   http: "^0.12.0"


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900